### PR TITLE
Fix suggested Windows XP ISO SHA1 hash

### DIFF
--- a/_virtual_machines/windows-xp.md
+++ b/_virtual_machines/windows-xp.md
@@ -12,7 +12,7 @@ download: https://github.com/utmapp/vm-downloads/releases/download/windows-templ
 ---
 
 ## Requirements
-You need an Windows XP installation ISO. There are many different ones that work but a good working image for English users is named `en_windows_xp_professional_sp3_Nov_2013_Incl_SATA_Drivers.iso` and has the SHA1 hash of `8fa76ccea145d050fc6a506ffbdedfe53282e5b4`.
+You need an Windows XP installation ISO. There are many different ones that work but a good working image for English users is named `en_windows_xp_professional_sp3_Nov_2013_Incl_SATA_Drivers.iso` and has the SHA1 hash of `6947e45f7eb50c873043af4713aa7cd43027efa7`.
 
 ## Installation
 1. Open the downloaded template `.utm` and select "Windows XP" in UTM.


### PR DESCRIPTION
I believe the suggested Windows XP ISO was meant to have a different SHA1 hash. From what I found, the current suggestion will actually get you a ISO named `xpsp3_5512.080413-2113_usa_x86fre_spcd.iso`, which doesn't appear to be bootable.

```console
$ sha1sum xpsp3_5512.080413-2113_usa_x86fre_spcd.iso
8fa76ccea145d050fc6a506ffbdedfe53282e5b4  xpsp3_5512.080413-2113_usa_x86fre_spcd.iso
$ file xpsp3_5512.080413-2113_usa_x86fre_spcd.iso
xpsp3_5512.080413-2113_usa_x86fre_spcd.iso: ISO 9660 CD-ROM filesystem data 'GRTMUPD_EN'
```

Another ISO available on the Internet Archive having the suggested name, has a different SHA1 hash and is bootable.

```console
$ sha1sum en_windows_xp_professional_sp3_Nov_2013_Incl_SATA_Drivers.iso
6947e45f7eb50c873043af4713aa7cd43027efa7  en_windows_xp_professional_sp3_Nov_2013_Incl_SATA_Drivers.iso
$ file en_windows_xp_professional_sp3_Nov_2013_Incl_SATA_Drivers.iso
en_windows_xp_professional_sp3_Nov_2013_Incl_SATA_Drivers.iso: ISO 9660 CD-ROM filesystem data 'GRTMPVOL_EN' (bootable)
```