### PR TITLE
Added instruction to handle network-not-found problem during Win11 ARM64 Installation

### DIFF
--- a/_virtual_machines/windows-11-arm.md
+++ b/_virtual_machines/windows-11-arm.md
@@ -44,3 +44,15 @@ Note that due to libslirp limitations, `ping` will not work and so Windows may t
 ### Networking does not work
 
 Make sure you installed the SPICE guest tools, which includes the network drivers.
+
+If, for example, installation stops because no network is found:
+
+1. Mount the guest tools ISO as VM's CD/DVD via UTM main window
+2. In Windows 11, press **Shift+F10** to open Command Prompt
+3. Type `D:` and then `spice-guest-tools-0.164.exe` (or any newer version you could have)
+4. Accept standard settings in installation wizard and, when prompted, AVOID immediate automatic reboot
+5. Exit from Command Prompt with `exit`
+6. Now the network is detected and you can go on with Windows installation
+7. Once installation is completed, before rebooting don't forget to unmount guest tools ISO
+
+For analogous missing drivers problem, it's preferable to configure host-guest shared folders only after installation and reboot (which completes the tools setup)


### PR DESCRIPTION
happened to me with Windows 11 Client ARM64 Insider Preview Build 22579